### PR TITLE
output_panel.c: Don't crash on center if no events have been received yet.

### DIFF
--- a/src/output_panel.c
+++ b/src/output_panel.c
@@ -724,6 +724,8 @@ static void handle_center_trace(GtkButton *b, struct output_panel *op)
 {
 	UNUSED(b);
 	struct snapshot *snst = op->snst;
+	if(!snst || !snst->events)
+		return;
 	uint64_t last_ev = snst->events[snst->events_wp];
 	double new_centering;
 	if(last_ev) {


### PR DESCRIPTION
Instead, return having done nothing.

Reproducing the crash is easy: simply disconnect or mute any audio input, start tg-timer, and click "center" while no ticks have been recognized.

The problem is fairly trivial: `op->snst` can be NULL (unlikely, but possibly if you click VERY VERY early before the UI has been completely drawn once), or `op->snst->events` can be NULL (very likely if no audio signal is present since startup).  I chose to guard against both at the same time.