### PR TITLE
.travis.yml: Work around known bug in travis-ci causing failed mac builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew cask uninstall oclint || true
       brew update;
       brew install gtk+3;
       brew install portaudio;


### PR DESCRIPTION
Described at https://github.com/travis-ci/travis-ci/issues/8826 there is a conflict between the gcc compiler and "oclint", which is a 'brew cask' that has been installed automatically before the mac builds start.  This is one of the workarounds frequently suggested. The "|| true" anticipates that if 'oclint' were not installed, the removal command might signal failure; we actually want to just continue in this case, because it means upstream has fixed the bug.