### PR TITLE
Run high pass filter in audio thread

### DIFF
--- a/src/algo.c
+++ b/src/algo.c
@@ -18,10 +18,6 @@
 
 #include "tg.h"
 
-struct filter {
-	double a0,a1,a2,b1,b2;
-};
-
 static int int_cmp(const void *a, const void *b)
 {
 	int x = *(int*)a;
@@ -29,7 +25,7 @@ static int int_cmp(const void *a, const void *b)
 	return x<y ? -1 : x>y ? 1 : 0;
 }
 
-static void make_hp(struct filter *f, double freq)
+void make_hp(struct filter *f, double freq)
 {
 	double K = tan(M_PI * freq);
 	double norm = 1 / (1 + K * sqrt(2) + K * K);
@@ -84,8 +80,6 @@ void setup_buffers(struct processing_buffers *b)
 	b->plan_e = fftwf_plan_dft_r2c_1d(b->sample_rate, b->tic_wf, b->tic_fft, FFTW_ESTIMATE);
 	b->plan_f = fftwf_plan_dft_r2c_1d(b->sample_rate, b->slice_wf, b->slice_fft, FFTW_ESTIMATE);
 	b->plan_g = fftwf_plan_dft_c2r_1d(b->sample_rate, b->slice_fft, b->slice_wf, FFTW_ESTIMATE);
-	b->hpf = malloc(sizeof(struct filter));
-	make_hp(b->hpf,(double)FILTER_CUTOFF/b->sample_rate);
 	b->lpf = malloc(sizeof(struct filter));
 	make_lp(b->lpf,(double)FILTER_CUTOFF/b->sample_rate);
 	b->events = malloc(EVENTS_MAX * sizeof(uint64_t));
@@ -116,7 +110,6 @@ void pb_destroy(struct processing_buffers *b)
 	fftwf_destroy_plan(b->plan_e);
 	fftwf_destroy_plan(b->plan_f);
 	fftwf_destroy_plan(b->plan_g);
-	free(b->hpf);
 	free(b->lpf);
 	free(b->events);
 #ifdef DEBUG
@@ -301,7 +294,6 @@ static void prepare_data(struct processing_buffers *b, int run_noise_suppressor)
 	int i;
 
 	memset(b->samples + b->sample_count, 0, b->sample_count * sizeof(float));
-	run_filter(b->hpf, b->samples, b->sample_count);
 	if(run_noise_suppressor) noise_suppressor(b);
 
 	for(i=0; i < b->sample_count; i++)

--- a/src/audio.c
+++ b/src/audio.c
@@ -91,7 +91,7 @@ static int paudio_callback(const void *input_buffer,
 	return 0;
 }
 
-int start_portaudio(int *nominal_sample_rate, double *real_sample_rate)
+int start_portaudio(int *nominal_sample_rate, double *real_sample_rate, bool light)
 {
 	if(pthread_mutex_init(&audio_mutex,NULL)) {
 		error("Failed to setup audio mutex");
@@ -122,7 +122,7 @@ int start_portaudio(int *nominal_sample_rate, double *real_sample_rate)
 	}
 	if(channels > 2) channels = 2;
 	info.channels = channels;
-	info.light = false;
+	info.light = light;
 	err = Pa_OpenDefaultStream(&stream,channels,0,paFloat32,PA_SAMPLE_RATE,paFramesPerBufferUnspecified,paudio_callback,&info);
 	if(err!=paNoError)
 		goto error;

--- a/src/computer.c
+++ b/src/computer.c
@@ -236,7 +236,7 @@ void computer_destroy(struct computer *c)
 struct computer *start_computer(int nominal_sr, int bph, double la, int cal, int light)
 {
 	if(light) nominal_sr /= 2;
-	set_audio_light(light);
+	set_audio_light(light, nominal_sr);
 
 	struct processing_buffers *p = malloc(NSTEPS * sizeof(struct processing_buffers));
 	int first_step = light ? FIRST_STEP_LIGHT : FIRST_STEP;

--- a/src/interface.c
+++ b/src/interface.c
@@ -917,11 +917,6 @@ static void start_interface(GApplication* app, void *p)
 
 	struct main_window *w = malloc(sizeof(struct main_window));
 
-	if(start_portaudio(&w->nominal_sr, &real_sr)) {
-		g_application_quit(app);
-		return;
-	}
-
 	w->app = GTK_APPLICATION(app);
 
 	w->zombie = 0;
@@ -933,6 +928,11 @@ static void start_interface(GApplication* app, void *p)
 	w->is_light = 0;
 
 	load_config(w);
+
+	if(start_portaudio(&w->nominal_sr, &real_sr, w->is_light)) {
+		g_application_quit(app);
+		return;
+	}
 
 	if(w->la < MIN_LA || w->la > MAX_LA) w->la = DEFAULT_LA;
 	if(w->bph < MIN_BPH || w->bph > MAX_BPH) w->bph = 0;

--- a/src/tg.h
+++ b/src/tg.h
@@ -83,7 +83,7 @@ struct processing_buffers {
 	float *samples, *samples_sc, *waveform, *waveform_sc, *tic_wf, *slice_wf, *tic_c;
 	fftwf_complex *fft, *sc_fft, *tic_fft, *slice_fft;
 	fftwf_plan plan_a, plan_b, plan_c, plan_d, plan_e, plan_f, plan_g;
-	struct filter *hpf, *lpf;
+	struct filter *lpf;
 	double period,sigma,be,waveform_max,phase,tic_pulse,toc_pulse,amp;
 	double cal_phase;
 	int waveform_max_i;
@@ -108,6 +108,10 @@ struct calibration_data {
 	uint64_t *events;
 };
 
+struct filter {
+	double a0,a1,a2,b1,b2;
+};
+
 void setup_buffers(struct processing_buffers *b);
 void pb_destroy(struct processing_buffers *b);
 struct processing_buffers *pb_clone(struct processing_buffers *p);
@@ -117,6 +121,7 @@ void setup_cal_data(struct calibration_data *cd);
 void cal_data_destroy(struct calibration_data *cd);
 int test_cal(struct processing_buffers *p);
 int process_cal(struct processing_buffers *p, struct calibration_data *cd);
+void make_hp(struct filter *f, double freq);
 
 /* audio.c */
 struct processing_data {
@@ -130,7 +135,7 @@ int terminate_portaudio();
 uint64_t get_timestamp(int light);
 int analyze_pa_data(struct processing_data *pd, int bph, double la, uint64_t events_from);
 int analyze_pa_data_cal(struct processing_data *pd, struct calibration_data *cd);
-void set_audio_light(bool light);
+void set_audio_light(bool light, int sample_rate);
 
 /* computer.c */
 struct snapshot {

--- a/src/tg.h
+++ b/src/tg.h
@@ -125,7 +125,7 @@ struct processing_data {
 	int is_light;
 };
 
-int start_portaudio(int *nominal_sample_rate, double *real_sample_rate);
+int start_portaudio(int *nominal_sample_rate, double *real_sample_rate, bool light);
 int terminate_portaudio();
 uint64_t get_timestamp(int light);
 int analyze_pa_data(struct processing_data *pd, int bph, double la, uint64_t events_from);


### PR DESCRIPTION
This moves the high pass filter out of prepare_data() and into the audio
callback.

prepare_data() will process the same data many times, up to 300 times,
as it is repeatedly called to processes buffers that mostly overlap the
last set of buffers.

Running the HPF on incoming audio will process about 300x less data
without changing the result.  This produces about a 4% overall speed
improvement.

In the next step in the audio processing, the noise filter, each sample
depends on every other sample in the buffer, so all samples need to be
re-processed each time the buffers change.  So it's not possible to do
more processing past the HPF as the audio is received.

I also benchmarked code that would apply the HPF while coping the data
out of from the portaudio buffer to the ring buffer.  I.e., a biquad
filter function that did not modify the data in place, but instead had
separate input and output pointers.  Dealing with the audio
combinations, mono/stereo, normal/light, took more code and there was no
significant speed improvement.

I also tried moving the HPF out of the audio callback and into the
compute thread, while still applying the filter only once to new audio,
but this was slower, doesn't spread the load across multiple CPUs as
well, and was more complex.