### PR TITLE
Fix issue preventing BPH below 14400 from working

### DIFF
--- a/src/algo.c
+++ b/src/algo.c
@@ -898,8 +898,12 @@ static void compute_cal(struct calibration_data *cd)
 void process(struct processing_buffers *p, int bph, double la, int light)
 {
 	prepare_data(p, !light);
+
 	p->ready = !compute_period(p,bph);
-	if(p->ready && p->period >= p->sample_rate / 2) {
+	/* Limit to 20% greater when period is known, or 500 ms when guessing period */
+	const int min_bph = bph ? bph : MIN_BPH;
+	const int max_period = (int)(1.2 * 3600 * 2) * p->sample_rate / min_bph;
+	if(p->ready && p->period >= max_period) {
 		debug("Detected period too long\n");
 		p->ready = 0;
 	}
@@ -907,6 +911,7 @@ void process(struct processing_buffers *p, int bph, double la, int light)
 		debug("abort after compute_period()\n");
 		return;
 	}
+
 	prepare_waveform(p);
 	p->ready = !compute_parameters(p);
 	if(!p->ready) {

--- a/src/algo.c
+++ b/src/algo.c
@@ -901,7 +901,7 @@ void process(struct processing_buffers *p, int bph, double la, int light)
 
 	p->ready = !compute_period(p,bph);
 	/* Limit to 20% greater when period is known, or 500 ms when guessing period */
-	const int min_bph = bph ? bph : MIN_BPH;
+	const int min_bph = bph ? bph : TYP_BPH;
 	const int max_period = (int)(1.2 * 3600 * 2) * p->sample_rate / min_bph;
 	if(p->ready && p->period >= max_period) {
 		debug("Detected period too long\n");

--- a/src/tg.h
+++ b/src/tg.h
@@ -57,7 +57,8 @@
 #define PAPERSTRIP_ZOOM_CAL 100
 #define PAPERSTRIP_MARGIN .2
 
-#define MIN_BPH 12000
+#define MIN_BPH 8100
+#define TYP_BPH 12000
 #define MAX_BPH 72000
 #define DEFAULT_BPH 21600
 #define MIN_LA 10 // deg


### PR DESCRIPTION
Periods (two beats) longer than 500 ms were rejected as too long.  This
effectively limits the low end of BPH to 14400.  Any slower and the
correct period length is greater than 500 ms, e.g. 12000 BPH is a 600 ms
period.

Change the limit to be 20% slower than the nominal value for the BPH.
If the BPH is set, then use that, when BPH is guessed, use MIN_BPH.

When MIN_BPH of 1200, this increases the max period to 720 ms when
guessing.  It could be longer if one were able to set a slower than
MIN_BPH period length.