### PR TITLE
Use re-sizable pane and allow a horizontal paperstrip 

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -44,6 +44,8 @@ g_key_file_save_to_file (GKeyFile     *key_file,
 
 #define g_key_file_get_int g_key_file_get_integer
 #define g_key_file_set_int g_key_file_set_integer // the devil may take glib
+#define g_key_file_get_bool g_key_file_get_boolean
+#define g_key_file_set_bool g_key_file_set_boolean
 
 void load_config(struct main_window *w)
 {

--- a/src/interface.c
+++ b/src/interface.c
@@ -694,6 +694,29 @@ static void load(GtkMenuItem *m, struct main_window *w)
 	gtk_widget_destroy(dialog);
 }
 
+/* Add a checkbox with name to the given menu, with initial state active and
+ * attach the supplied callback and parameter to the toggled signal.  Set is set
+ * before attaching the signal, so the callback is not called when created.  */
+static GtkWidget* add_checkbox(GtkWidget* menu, const char* name, bool active, GCallback callback, void* param)
+{
+	GtkWidget *checkbox = gtk_check_menu_item_new_with_label(name);
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(checkbox), active);
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), checkbox);
+	g_signal_connect(checkbox, "toggled", callback, param);
+	return checkbox;
+}
+
+/* Add a menu item with given label to the given menu, with the supplied initial
+* sensitivity, callback, and callback parameter.  */
+static GtkWidget* add_menu_item(GtkWidget* menu, const char* label, bool sensitive, GCallback callback, void* param)
+{
+	GtkWidget *item = gtk_menu_item_new_with_label(label);
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), item);
+	gtk_widget_set_sensitive(item, sensitive);
+	g_signal_connect(item, "activate", callback, param);
+	return item;
+}
+
 /* Set up the main window and populate with widgets */
 static void init_main_window(struct main_window *w)
 {
@@ -800,47 +823,29 @@ static void init_main_window(struct main_window *w)
 	gtk_box_pack_end(GTK_BOX(hbox), command_menu_button, FALSE, FALSE, 0);
 	
 	// ... Open
-	GtkWidget *open_item = gtk_menu_item_new_with_label("Open");
-	gtk_menu_shell_append(GTK_MENU_SHELL(command_menu), open_item);
-	g_signal_connect(open_item, "activate", G_CALLBACK(load), w);
+	add_menu_item(command_menu, "Open", true, G_CALLBACK(load), w);
 
 	// ... Save
-	w->save_item = gtk_menu_item_new_with_label("Save current display");
-	gtk_menu_shell_append(GTK_MENU_SHELL(command_menu), w->save_item);
-	g_signal_connect(w->save_item, "activate", G_CALLBACK(save_current), w);
-	gtk_widget_set_sensitive(w->save_item, FALSE);
+	w->save_item = add_menu_item(command_menu, "Save current display", false, G_CALLBACK(save_current), w);
 
 	// ... Save all
-	w->save_all_item = gtk_menu_item_new_with_label("Save all snapshots");
-	gtk_menu_shell_append(GTK_MENU_SHELL(command_menu), w->save_all_item);
-	g_signal_connect(w->save_all_item, "activate", G_CALLBACK(save_all), w);
-	gtk_widget_set_sensitive(w->save_all_item, FALSE);
+	w->save_all_item = add_menu_item(command_menu, "Save all snapshots", false, G_CALLBACK(save_all), w);
 
 	gtk_menu_shell_append(GTK_MENU_SHELL(command_menu), gtk_separator_menu_item_new());
 
 	// ... Light checkbox
-	GtkWidget *light_checkbox = gtk_check_menu_item_new_with_label("Light algorithm");
-	gtk_menu_shell_append(GTK_MENU_SHELL(command_menu), light_checkbox);
-	g_signal_connect(light_checkbox, "toggled", G_CALLBACK(handle_light), w);
-	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(light_checkbox), w->is_light);
+	add_checkbox(command_menu, "Light algorithm", w->is_light, G_CALLBACK(handle_light), w);
 
 	// ... Calibrate checkbox
-	w->cal_button = gtk_check_menu_item_new_with_label("Calibrate");
-	gtk_menu_shell_append(GTK_MENU_SHELL(command_menu), w->cal_button);
-	g_signal_connect(w->cal_button, "toggled", G_CALLBACK(handle_calibrate), w);
+	w->cal_button = add_checkbox(command_menu, "Calibrate", false, G_CALLBACK(handle_calibrate), w);
 
 	gtk_menu_shell_append(GTK_MENU_SHELL(command_menu), gtk_separator_menu_item_new());
 
 	// ... Close all
-	w->close_all_item = gtk_menu_item_new_with_label("Close all snapshots");
-	gtk_menu_shell_append(GTK_MENU_SHELL(command_menu), w->close_all_item);
-	g_signal_connect(w->close_all_item, "activate", G_CALLBACK(close_all), w);
-	gtk_widget_set_sensitive(w->close_all_item, FALSE);
+	w->close_all_item = add_menu_item(command_menu, "Close all snapshots", false, G_CALLBACK(close_all), w);
 
 	// ... Quit
-	GtkWidget *quit_item = gtk_menu_item_new_with_label("Quit");
-	gtk_menu_shell_append(GTK_MENU_SHELL(command_menu), quit_item);
-	g_signal_connect(quit_item, "activate", G_CALLBACK(handle_quit), w);
+	add_menu_item(command_menu, "Quit", true, G_CALLBACK(handle_quit), w);
 
 	gtk_widget_show_all(command_menu);
 

--- a/src/output_panel.c
+++ b/src/output_panel.c
@@ -322,10 +322,9 @@ static void expose_waveform(
 	int width = temp.width;
 	int height = temp.height;
 
-	gtk_widget_get_allocation(gtk_widget_get_toplevel(da), &temp);
-	int font = temp.width / 90;
-	if(font < 12)
-		font = 12;
+	int font = width / 25;
+	font = font < 12 ? 12 : font > 24 ? 24 : font;
+
 	int i;
 
 	cairo_set_font_size(c,font);
@@ -670,18 +669,14 @@ static gboolean paperstrip_draw_event(GtkWidget *widget, cairo_t *c, struct outp
 	cairo_line_to(c, right_margin + .5, height - 20.5);
 	cairo_fill(c);
 
-	char s[100];
-	cairo_text_extents_t extents;
+	int font = width / 25;
+	cairo_set_font_size(c, font < 12 ? 12 : font > 24 ? 24 : font);
 
-	gtk_widget_get_allocation(gtk_widget_get_toplevel(widget), &temp);
-	int font = temp.width / 90;
-	if(font < 12)
-		font = 12;
-	cairo_set_font_size(c,font);
-
-	sprintf(s, "%.1f ms", snst->calibrate ?
+	char s[32];
+	snprintf(s, sizeof(s), "%.1f ms", snst->calibrate ?
 				1000. / zoom_factor :
 				3600000. / (snst->guessed_bph * zoom_factor));
+	cairo_text_extents_t extents;
 	cairo_text_extents(c,s,&extents);
 	cairo_move_to(c, (width - extents.x_advance)/2, height - 30);
 	cairo_show_text(c,s);

--- a/src/output_panel.c
+++ b/src/output_panel.c
@@ -835,18 +835,21 @@ static GtkWidget* create_waveforms(struct output_panel *op, bool vertical)
 
 	// Tic waveform area
 	op->tic_drawing_area = gtk_drawing_area_new();
+	gtk_widget_set_size_request(op->tic_drawing_area, 300, 150);
 	gtk_box_pack_start(GTK_BOX(box), op->tic_drawing_area, TRUE, TRUE, 0);
 	g_signal_connect (op->tic_drawing_area, "draw", G_CALLBACK(tic_draw_event), op);
 	gtk_widget_set_events(op->tic_drawing_area, GDK_EXPOSURE_MASK);
 
 	// Toc waveform area
 	op->toc_drawing_area = gtk_drawing_area_new();
+	gtk_widget_set_size_request(op->toc_drawing_area, 300, 150);
 	gtk_box_pack_start(GTK_BOX(box), op->toc_drawing_area, TRUE, TRUE, 0);
 	g_signal_connect (op->toc_drawing_area, "draw", G_CALLBACK(toc_draw_event), op);
 	gtk_widget_set_events(op->toc_drawing_area, GDK_EXPOSURE_MASK);
 
 	// Period waveform area
 	op->period_drawing_area = gtk_drawing_area_new();
+	gtk_widget_set_size_request(op->period_drawing_area, 300, 150);
 	gtk_box_pack_start(GTK_BOX(box), op->period_drawing_area, TRUE, TRUE, 0);
 	g_signal_connect (op->period_drawing_area, "draw", G_CALLBACK(period_draw_event), op);
 	gtk_widget_set_events(op->period_drawing_area, GDK_EXPOSURE_MASK);
@@ -865,9 +868,10 @@ static GtkWidget* create_waveforms(struct output_panel *op, bool vertical)
  * horizontal paperstrip orientation.  Puts container in the panel and shows it. */
 static void place_displays(struct output_panel *op, GtkWidget *paperstrip, GtkWidget *waveforms, bool vertical)
 {
-	op->displays = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
-	gtk_box_pack_start(GTK_BOX(op->displays), paperstrip, FALSE, TRUE, 0);
-	gtk_box_pack_start(GTK_BOX(op->displays), waveforms, TRUE, TRUE, 0);
+	op->displays = gtk_paned_new(GTK_ORIENTATION_HORIZONTAL);
+	gtk_paned_set_wide_handle(GTK_PANED(op->displays), TRUE);
+	gtk_paned_pack1(GTK_PANED(op->displays), paperstrip, FALSE, FALSE);
+	gtk_paned_pack2(GTK_PANED(op->displays), waveforms, TRUE, FALSE);
 
 	gtk_box_pack_end(GTK_BOX(op->panel), op->displays, TRUE, TRUE, 0);
 	gtk_widget_show(op->displays);

--- a/src/tg.h
+++ b/src/tg.h
@@ -200,11 +200,14 @@ struct output_panel {
 	GtkWidget *panel;
 
 	GtkWidget *output_drawing_area;
+	GtkWidget *displays;
 	GtkWidget *tic_drawing_area;
 	GtkWidget *toc_drawing_area;
 	GtkWidget *period_drawing_area;
 	GtkWidget *paperstrip_drawing_area;
 	GtkWidget *clear_button;
+	GtkWidget *left_button;
+	GtkWidget *right_button;
 #ifdef DEBUG
 	GtkWidget *debug_drawing_area;
 #endif

--- a/src/tg.h
+++ b/src/tg.h
@@ -201,22 +201,28 @@ struct output_panel {
 
 	GtkWidget *output_drawing_area;
 	GtkWidget *displays;
+	GtkWidget *waveforms_box;
 	GtkWidget *tic_drawing_area;
 	GtkWidget *toc_drawing_area;
 	GtkWidget *period_drawing_area;
+	GtkWidget *paperstrip_box;
 	GtkWidget *paperstrip_drawing_area;
 	GtkWidget *clear_button;
 	GtkWidget *left_button;
 	GtkWidget *right_button;
+	GtkWidget *zoom_button;
 #ifdef DEBUG
 	GtkWidget *debug_drawing_area;
 #endif
+	bool vertical_layout;
+
 	struct computer *computer;
 	struct snapshot *snst;
 };
 
 void initialize_palette();
-struct output_panel *init_output_panel(struct computer *comp, struct snapshot *snst, int border);
+struct output_panel *init_output_panel(struct computer *comp, struct snapshot *snst, int border, bool vertical_layout);
+void set_panel_layout(struct output_panel *op, bool vertical);
 void redraw_op(struct output_panel *op);
 void op_set_snapshot(struct output_panel *op, struct snapshot *snst);
 void op_set_border(struct output_panel *op, int i);
@@ -253,6 +259,8 @@ struct main_window {
 	int cal; // 0.1 s/d
 	int nominal_sr;
 
+	bool vertical_layout;
+
 	GKeyFile *config_file;
 	gchar *config_file_name;
 	struct conf_data *conf_data;
@@ -275,7 +283,8 @@ void error(char *format,...);
 	OP(bph, bph, int) \
 	OP(lift_angle, la, double) \
 	OP(calibration, cal, int) \
-	OP(light_algorithm, is_light, int)
+	OP(light_algorithm, is_light, int) \
+	OP(vertical_paperstrip, vertical_layout, bool)
 
 struct conf_data {
 #define DEF(NAME,PLACE,TYPE) TYPE PLACE;


### PR DESCRIPTION
This lets the pane between the paperstrip and waveforms be resized.  If one is currently more interested in one of the other.

Also adds a menu and config file option to re-arrange the widgets so that the paperstrip is drawn horizontally instead of vertically.  This allows much more space, and time, for the paperstrip, which is often much more useful than the waveforms.  The layout can be changed while running.

See commits for much more detail on the changes.

Example of maximizing the paperstrip in vertical layout:
![image](https://user-images.githubusercontent.com/35062987/108347204-19b09200-7195-11eb-8495-d78e0e7c3c63.png)

Example of the horizontal paperstrip.  The time show in the strip is almost double what the vertical strip fits.
![image](https://user-images.githubusercontent.com/35062987/108347087-fb4a9680-7194-11eb-8380-48b0126307d7.png)


