### PR TITLE
Misc fixes for light mode

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -91,7 +91,7 @@ static int paudio_callback(const void *input_buffer,
 	return 0;
 }
 
-int start_portaudio(int *nominal_sample_rate, double *real_sample_rate)
+int start_portaudio(int *nominal_sample_rate, double *real_sample_rate, bool light)
 {
 	if(pthread_mutex_init(&audio_mutex,NULL)) {
 		error("Failed to setup audio mutex");
@@ -122,7 +122,7 @@ int start_portaudio(int *nominal_sample_rate, double *real_sample_rate)
 	}
 	if(channels > 2) channels = 2;
 	info.channels = channels;
-	info.light = false;
+	info.light = light;
 	err = Pa_OpenDefaultStream(&stream,channels,0,paFloat32,PA_SAMPLE_RATE,paFramesPerBufferUnspecified,paudio_callback,&info);
 	if(err!=paNoError)
 		goto error;

--- a/src/interface.c
+++ b/src/interface.c
@@ -917,11 +917,6 @@ static void start_interface(GApplication* app, void *p)
 
 	struct main_window *w = malloc(sizeof(struct main_window));
 
-	if(start_portaudio(&w->nominal_sr, &real_sr)) {
-		g_application_quit(app);
-		return;
-	}
-
 	w->app = GTK_APPLICATION(app);
 
 	w->zombie = 0;
@@ -933,6 +928,11 @@ static void start_interface(GApplication* app, void *p)
 	w->is_light = 0;
 
 	load_config(w);
+
+	if(start_portaudio(&w->nominal_sr, &real_sr, w->is_light)) {
+		g_application_quit(app);
+		return;
+	}
 
 	if(w->la < MIN_LA || w->la > MAX_LA) w->la = DEFAULT_LA;
 	if(w->bph < MIN_BPH || w->bph > MAX_BPH) w->bph = 0;

--- a/src/tg.h
+++ b/src/tg.h
@@ -125,7 +125,7 @@ struct processing_data {
 	int is_light;
 };
 
-int start_portaudio(int *nominal_sample_rate, double *real_sample_rate);
+int start_portaudio(int *nominal_sample_rate, double *real_sample_rate, bool light);
 int terminate_portaudio();
 uint64_t get_timestamp(int light);
 int analyze_pa_data(struct processing_data *pd, int bph, double la, uint64_t events_from);


### PR DESCRIPTION
There is race when switching between normal and light mode.  Fix this.

If light mode is set in the config file, the app will start in normal anyway and then switch to light mode after processing a bit of audio.  This is annoying and can be fixed so it starts in the correct mode to begin with.