### PR TITLE
Processes only need steps for large speedup

### DIFF
--- a/src/algo.c
+++ b/src/algo.c
@@ -452,7 +452,7 @@ static int compute_period(struct processing_buffers *b, int bph)
 	if(count > 1)
 		b->sigma = sqrt((sq_sum - count * estimate * estimate)/ (count-1));
 	else
-		b->sigma = b->period;
+		b->sigma = 0;	// No std. dev. estimate possible with just 1 sample
 	return 0;
 }
 

--- a/src/computer.c
+++ b/src/computer.c
@@ -125,7 +125,7 @@ static void compute_update(struct computer *c)
 		c->actv->pb = pb_clone(&ps[step]);
 		c->actv->is_old = 0;
 		/* Signal's range is 0 to NSTEPS, while step is -1 to NSTEPS-1, i.e. signal = step+1 */
-		c->actv->signal = step == NSTEPS-1 && ps[step].amp < 0 ? step : step+1;
+		c->actv->signal = step+1;
 	} else {
 		debug("---\n");
 		c->actv->is_old = 1;

--- a/src/output_panel.c
+++ b/src/output_panel.c
@@ -112,11 +112,20 @@ static double amplitude_to_time(double lift_angle, double amp)
 	return asin(lift_angle / (2 * amp)) / M_PI;
 }
 
-static double draw_watch_icon(cairo_t *c, int signal, int happy, int light)
+/** Draw the watch graphic that has status info.
+ *
+ * @param[in,out] c Cairo context to use.
+ * @param signal Signal level, i.e. dots, 0 to NSTEPS inclusive.
+ * @param partial Specified signal level is only partially achieved.
+ * @param happy Green happy face or red frowny face.
+ * @param light Indicate light sampling mode.
+ * @return Y coodinate of top margin.
+ */
+
+static double draw_watch_icon(cairo_t *c, int signal, bool partial, bool happy, bool light)
 {
-	happy = !!happy;
-	cairo_set_line_width(c,3);
-	cairo_set_source(c,happy?green:red);
+	cairo_set_line_width(c, 3);
+	cairo_set_source(c, happy ? green : red);
 	cairo_move_to(c, OUTPUT_WINDOW_HEIGHT * 0.5, OUTPUT_WINDOW_HEIGHT * 0.5);
 	cairo_line_to(c, OUTPUT_WINDOW_HEIGHT * 0.75, OUTPUT_WINDOW_HEIGHT * (0.75 - 0.5*happy));
 	cairo_move_to(c, OUTPUT_WINDOW_HEIGHT * 0.5, OUTPUT_WINDOW_HEIGHT * 0.5);
@@ -126,7 +135,7 @@ static double draw_watch_icon(cairo_t *c, int signal, int happy, int light)
 	cairo_stroke(c);
 	int l = OUTPUT_WINDOW_HEIGHT * 0.8 / (2*NSTEPS - 1);
 	int i;
-	cairo_set_line_width(c,1);
+	cairo_set_line_width(c, 1);
 	for(i = 0; i < signal; i++) {
 		cairo_move_to(c, OUTPUT_WINDOW_HEIGHT + 0.5*l, OUTPUT_WINDOW_HEIGHT * 0.9 - 2*i*l);
 		cairo_line_to(c, OUTPUT_WINDOW_HEIGHT + 1.5*l, OUTPUT_WINDOW_HEIGHT * 0.9 - 2*i*l);
@@ -134,7 +143,7 @@ static double draw_watch_icon(cairo_t *c, int signal, int happy, int light)
 		cairo_line_to(c, OUTPUT_WINDOW_HEIGHT + 0.5*l, OUTPUT_WINDOW_HEIGHT * 0.9 - (2*i+1)*l);
 		cairo_line_to(c, OUTPUT_WINDOW_HEIGHT + 0.5*l, OUTPUT_WINDOW_HEIGHT * 0.9 - 2*i*l);
 		cairo_stroke_preserve(c);
-		cairo_fill(c);
+		if (i < signal-1 || !partial) cairo_fill(c);
 	}
 	if(light) {
 		int l = OUTPUT_WINDOW_HEIGHT * 0.15;
@@ -194,7 +203,8 @@ static gboolean output_draw_event(GtkWidget *widget, cairo_t *c, struct output_p
 	struct processing_buffers *p = snst->pb;
 	int old = snst->is_old;
 
-	double x = draw_watch_icon(c,snst->signal,snst->calibrate ? snst->signal==NSTEPS : snst->signal, snst->is_light);
+	double x = draw_watch_icon(c, snst->signal, snst->amp <= 0,
+				   snst->signal >= (snst->calibrate ? NSTEPS : 1), snst->is_light);
 
 	cairo_text_extents_t extents;
 

--- a/src/tg.h
+++ b/src/tg.h
@@ -75,6 +75,8 @@
 #endif
 
 #define UNUSED(X) (void)(X)
+#define BIT(n) (1u << (n))
+#define BITMASK(n) ((1u << (n)) - 1u)
 
 /* algo.c */
 struct processing_buffers {
@@ -122,13 +124,15 @@ int process_cal(struct processing_buffers *p, struct calibration_data *cd);
 struct processing_data {
 	struct processing_buffers *buffers;
 	uint64_t last_tic;
+	int last_step;	//!< Guess of step (buffers index) to try first, based on last iteration
 	int is_light;
 };
 
 int start_portaudio(int *nominal_sample_rate, double *real_sample_rate);
 int terminate_portaudio();
 uint64_t get_timestamp(int light);
-int analyze_pa_data(struct processing_data *pd, int bph, double la, uint64_t events_from);
+void fill_buffers(struct processing_buffers *ps, int light);
+bool analyze_pa_data(struct processing_data *pd, int step, int bph, double la, uint64_t events_from);
 int analyze_pa_data_cal(struct processing_data *pd, struct calibration_data *cd);
 void set_audio_light(bool light);
 


### PR DESCRIPTION
I measured this as reducing CPU usage from ~78% to ~45%.  Almost doubling the speed, which is expected as described below.

Tg processes the audio in a series of steps that double in size:  2, 4, 8, and then 16 seconds long.  This is the one to four dots shown in the display.

Tg starts at step 1 (2 seconds) and goes up, stopping if a step doesn't pass.  Data from smaller steps isn't used if a larger step passes.

This means when running at a constant step 4 with good signal, CPU usage is almost double what it needs to be, since steps 1-3 are processed and unused and add up to 14 seconds, almost as much as step 4's 16 seconds.

Change this to start at the previous iteration's step.  With good signal, only step 4 will be processed and CPU usage is cut almost in half.  If the previous step fails, it will try smaller steps.  If it passes and is not yet the top step, it will try larger steps.

End result should end up on the same step as before, but get there sooner.  It could be slower if the step drops a lot, e.g. from 4 to 0, but this happens far less often than the step saying the same or nearly the same.

I also change the dot display to consistently indicate averaging interval and amplitude measurement.  It did both before in an inconsistent way.

See commit messages for more details.